### PR TITLE
Support storing vector props in Gremlin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ pom.xml*
 .lein-*
 .#*
 .nrepl-*
+.lsp/.cache/
+.clj-kondo/.cache/
+.portal/

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ardoq/archimedes "3.0.0.1"
+(defproject ardoq/archimedes "3.0.0.3"
   :description "Clojure wrapper for Tinkerpop Blueprints"
   :url "https://github.com/clojurewerkz/archimedes"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ardoq/archimedes "3.0.0.3"
+(defproject ardoq/archimedes "4.0.0"
   :description "Clojure wrapper for Tinkerpop Blueprints"
   :url "https://github.com/clojurewerkz/archimedes"
   :license {:name "Eclipse Public License"
@@ -15,7 +15,8 @@
                                      [commons-io/commons-io "2.4"]]}
              :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :master {:dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}}
+             :1.11    {:dependencies [[org.clojure/clojure "1.11.1"]]}
+             :master {:dependencies [[org.clojure/clojure "1.8.0"]]}}
   :aliases {"all" ["with-profile" "dev:dev,1.5:dev,1.7:dev,master"]}
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
                              :snapshots false

--- a/src/clojure/clojurewerkz/archimedes/element.clj
+++ b/src/clojure/clojurewerkz/archimedes/element.clj
@@ -1,6 +1,6 @@
 (ns clojurewerkz.archimedes.element
   (:refer-clojure :exclude [keys vals assoc! dissoc! get])
-  (:import [org.apache.tinkerpop.gremlin.structure Element VertexProperty$Cardinality]))
+  (:import [org.apache.tinkerpop.gremlin.structure Edge Element Vertex VertexProperty$Cardinality]))
 
 (defn get
   ([^Element elem key]
@@ -27,15 +27,28 @@
   ;;Important when using types. You aren't ever going to change a
   ;;user's id for example.
   (doseq [[key value] (partition 2 kvs)]
-    (if (set? value)
-      (.property elem VertexProperty$Cardinality/set (name key) value (to-array []))
-      (.property elem (name key) value)))
+    (let [value' (if (coll? value)
+                   ;; The Graph serialization likely doesn't support Clojure coll
+                   ;; classes but quite likely it does handle arrays
+                   (into-array Object value)
+                   value)]
+      (if (instance? Vertex elem)
+        (cond
+          (set? value)
+          (.property elem VertexProperty$Cardinality/set (name key) value' (to-array []))
+          (sequential? value)
+          (.property elem VertexProperty$Cardinality/list (name key) value' (to-array []))
+          :else
+          (.property elem VertexProperty$Cardinality/single (name key) value' (to-array [])))
+        (.property elem (name key) value'))))
   elem)
 
 (defn merge!
   [^Element elem & maps]
   (doseq [d maps]
-    (apply assoc! (cons elem (flatten (into [] d)))))
+    (apply assoc! elem (if (map? d)
+                         (apply concat (into [] d))
+                         (flatten (into [] d)))))
   elem)
 
 (defn dissoc!

--- a/src/clojure/clojurewerkz/archimedes/graph.clj
+++ b/src/clojure/clojurewerkz/archimedes/graph.clj
@@ -1,7 +1,8 @@
 (ns clojurewerkz.archimedes.graph
-  (:import (org.apache.tinkerpop.gremlin.structure Element Graph Graph$Features Graph$Features$GraphFeatures)
-           (org.apache.tinkerpop.gremlin.tinkergraph.structure TinkerFactory)
-           ))
+  (:import (org.apache.tinkerpop.gremlin.structure Element Graph Graph$Features 
+             Graph$Features$GraphFeatures
+             Graph$Features$VertexFeatures)
+           (org.apache.tinkerpop.gremlin.tinkergraph.structure TinkerFactory)))
 
 (def ^{:dynamic true} *element-id-key* :__id__)
 
@@ -41,6 +42,9 @@
 
 (defn supports-graph-feature [g s]
   (-> g (.features) (.supports Graph$Features$GraphFeatures s)))
+
+(defn supports-vertex-feature [g s]
+  (-> g (.features) (.supports Graph$Features$VertexFeatures s)))
 
 ;;TODO Transactions need to be much more fine grain in terms of
 ;;control. And expections as well. new-transaction will only work on a

--- a/test/clojurewerkz/archimedes/element_test.clj
+++ b/test/clojurewerkz/archimedes/element_test.clj
@@ -25,14 +25,16 @@
 
 (deftest test-create-with-properties!
   (let [g (clean-tinkergraph)
-        a (v/create-with-id!  g 100 {:str "s", :num 1, :vec [1 2] :set #{"a" "b"}})
+        a (v/create-with-id!  g 100 {:str "s", :num 1, :v1 [1], :vec [1 2] :set #{"a" "b"}})
         v-map (v/to-map a)]
     (is (= {:str "s", :num 1}
            (select-keys v-map [:str :num])))
-    (is (java.util.Arrays/equals (into-array Object ["a" "b"]) (:set v-map))
-      "Clojure vectors are stored as Java arrays (for compatibility)")
-    (is (java.util.Arrays/equals (into-array Object [1 2]) (:vec v-map))
-      "Clojure sets are stored as Java arrays (for compatibility)")))
+    (is (= [1] (:v1 v-map))
+      "Clojure vectors is read as a Java List (single element)")
+    (is (= #{"a" "b"} (:set v-map))
+      "Clojure sets is read as a Java Set (multiple elements)")
+    (is (= [1 2] (:vec v-map))
+      "Clojure vectors is read as a Java List")))
 
 (deftest test-remove-property!
   (let [g (clean-tinkergraph)

--- a/test/clojurewerkz/archimedes/element_test.clj
+++ b/test/clojurewerkz/archimedes/element_test.clj
@@ -19,9 +19,20 @@
   (let [g (clean-tinkergraph)
         a (v/create-with-id!  g 100)
         b (v/create-with-id!  g 101)
-        c (e/connect-with-id! g 102 a :label b )]
+        c (e/connect-with-id! g 102 a :label b)]
     (is (= java.lang.Integer (type (v/id-of a))))
     (is (= java.lang.Integer (type (e/id-of c))))))
+
+(deftest test-create-with-properties!
+  (let [g (clean-tinkergraph)
+        a (v/create-with-id!  g 100 {:str "s", :num 1, :vec [1 2] :set #{"a" "b"}})
+        v-map (v/to-map a)]
+    (is (= {:str "s", :num 1}
+           (select-keys v-map [:str :num])))
+    (is (java.util.Arrays/equals (into-array Object ["a" "b"]) (:set v-map))
+      "Clojure vectors are stored as Java arrays (for compatibility)")
+    (is (java.util.Arrays/equals (into-array Object [1 2]) (:vec v-map))
+      "Clojure sets are stored as Java arrays (for compatibility)")))
 
 (deftest test-remove-property!
   (let [g (clean-tinkergraph)


### PR DESCRIPTION
Fixes https://github.com/clojurewerkz/archimedes/issues/24

As described in https://github.com/clojurewerkz/archimedes/issues/24, we were unable to store vectors as values in TinkerPop because of flatten.

This replaces the IMO unnecessary `flatten` with the much more, single-level `apply concat`
and sets correctly cardinality on the field.

I decided to keep the old code for non-map inputs (as those some tests provide) to keep backwards compatibility with any clients using those.

Notice that only some types can be serialized by the graph backend. F.ex. TinkerPop uses Kryo, which supports
these classes https://github.com/EsotericSoftware/kryo/blob/kryo-parent-3.0.3/src/com/esotericsoftware/kryo/Kryo.java#L179-L224

NOTE: I decided to bump major version b/c it is kind of breaking change since sequences, sets will now be stored differently in the graph.